### PR TITLE
Multiple CVE additions for Java librairies (Struts, Axis, Commons File Upload, ESAPI)

### DIFF
--- a/database/java/2013/5960.yaml
+++ b/database/java/2013/5960.yaml
@@ -1,0 +1,15 @@
+cve: 2013-5960
+title: "ESAPI: MAC Bypass in Symmetric Encryption"
+description: >
+    The authenticated-encryption feature in the symmetric-encryption implementation in the OWASP Enterprise Security API (ESAPI) for Java 2.x before 2.1.1 does not properly resist tampering with serialized ciphertext, which makes it easier for remote attackers to bypass intended cryptographic protection mechanisms via an attack against the intended cipher mode in a non-default configuration, a different vulnerability than CVE-2013-5679.
+cvss_v2: 5.8
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-5960
+    - http://owasp-esapi-java.googlecode.com/svn/trunk/documentation/ESAPI-security-bulletin1.pdf
+    - http://www.synacktiv.com/ressources/synacktiv_owasp_esapi_hmac_bypass.pdf
+    - http://off-the-wall-security.blogspot.ca/2014/03/esapi-no-longer-owasp-flagship-project.html
+affected:
+    - groupId: "org.owasp.esapi"
+      artifactId: "esapi"
+      version:
+        - "<=2.1.0"

--- a/database/java/2013/5979.yaml
+++ b/database/java/2013/5979.yaml
@@ -1,0 +1,17 @@
+cve: 2013-5979
+title: "ESAPI: MAC Bypass in Symmetric Encryption"
+description: >
+    The authenticated-encryption feature in the symmetric-encryption implementation in the OWASP Enterprise Security API (ESAPI) for Java 2.x before 2.1.0 does not properly resist tampering with serialized ciphertext, which makes it easier for remote attackers to bypass intended cryptographic protection mechanisms via an attack against authenticity in the default configuration, involving a null MAC and a zero MAC length.
+cvss_v2: 2.6
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-5679
+    - http://owasp-esapi-java.googlecode.com/svn/trunk/documentation/ESAPI-security-bulletin1.pdf
+    - http://blog.h3xstream.com/2013/08/esapi-when-authenticated-encryption.html
+    - http://www.synacktiv.com/ressources/synacktiv_owasp_esapi_hmac_bypass.pdf
+affected:
+    - groupId: "org.owasp.esapi"
+      artifactId: "esapi"
+      version:
+        - "<=2.0.1"
+      fixedin:
+        - ">=2.1.0"

--- a/database/java/2014/0050.yaml
+++ b/database/java/2014/0050.yaml
@@ -1,0 +1,18 @@
+cve: 2014-0050
+title: "Apache Commons FileUpload: Denial of service"
+description: >
+    MultipartStream.java in Apache Commons FileUpload before 1.3.1, as used in Apache Tomcat, JBoss Web, and other products, allows remote attackers to cause a denial of service (infinite loop and CPU consumption) via a crafted Content-Type header that bypasses a loop's intended exit conditions.
+cvss_v2: 5.0
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0050
+    - http://blog.spiderlabs.com/2014/02/cve-2014-0050-exploit-with-boundaries-loops-without-boundaries.html
+    - http://svn.apache.org/viewvc?view=revision&revision=1565143
+    - http://mail-archives.apache.org/mod_mbox/www-announce/201402.mbox/%3C52F373FC.9030907@apache.org%3E
+    - http://struts.apache.org/docs/s2-020.html
+affected:
+    - groupId: "commons-fileupload"
+      artifactId: "commons-fileupload"
+      version:
+        - "<=1.3"
+      fixedin:
+        - ">=1.3.1"

--- a/database/java/2014/0112.yaml
+++ b/database/java/2014/0112.yaml
@@ -1,0 +1,15 @@
+cve: 2014-0112
+title: "Apache Struts 2: Incomplete fix for ClassLoader manipulation via ParametersInterceptor"
+description: >
+     ParametersInterceptor in Apache Struts before 2.3.16.2 does not properly restrict access to the getClass method, which allows remote attackers to "manipulate" the ClassLoader and execute arbitrary code via a crafted request. NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0094.
+cvss_v2: 6.4
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0112
+    - http://struts.apache.org/docs/s2-021.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.3.16.1"
+      fixedin:
+        - ">=2.3.16.2"

--- a/database/java/2014/0113.yaml
+++ b/database/java/2014/0113.yaml
@@ -1,0 +1,15 @@
+cve: 2014-0113
+title: "Apache Struts 2: Classloader manipulation via CookieInterceptor"
+description: >
+     CookieInterceptor in Apache Struts before 2.3.16.2, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to "manipulate" the ClassLoader and execute arbitrary code via a crafted request. NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0094.
+cvss_v2: 6.4
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0113
+    - http://struts.apache.org/docs/s2-021.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.3.16.1"
+      fixedin:
+        - ">=2.3.16.2"

--- a/database/java/2014/0116.yaml
+++ b/database/java/2014/0116.yaml
@@ -1,0 +1,15 @@
+cve: 2014-0116
+title: "Apache Struts 2: Classloader manipulation via CookieInterceptor"
+description: >
+     CookieInterceptor in Apache Struts 2.x before 2.3.16.3, when a wildcard cookiesName value is used, does not properly restrict access to the getClass method, which allows remote attackers to "manipulate" the ClassLoader and modify session state via a crafted request. NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-0113.
+cvss_v2: 5.8
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0116
+    - http://struts.apache.org/docs/s2-022.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.3.16.2"
+      fixedin:
+        - ">=2.3.16.3"

--- a/database/java/2014/3596.yaml
+++ b/database/java/2014/3596.yaml
@@ -1,0 +1,18 @@
+cve: 2014-3596
+title: "Apache Axis: Improper hostname verification in certificate verification"
+description: >
+    The getCN function in Apache Axis 1.4 and earlier does not properly verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a certificate with a subject that specifies a common name in a field that is not the CN field. NOTE: this issue exists because of an incomplete fix for CVE-2012-5784.
+cvss_v2: 5.8
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3596
+    - https://issues.apache.org/jira/browse/AXIS-2905
+affected:
+    - groupId: "org.apache.axis"
+      artifactId: "axis"
+      version:
+        - "<=1.4"
+
+    - groupId: "axis"
+      artifactId: "axis"
+      version:
+        - "<=1.4"

--- a/database/java/2014/7809.yaml
+++ b/database/java/2014/7809.yaml
@@ -1,0 +1,16 @@
+cve: 2014-7809
+title: "Apache Struts 2: Predictable CSRF token"
+description: >
+    Apache Struts 2.0.0 through 2.3.x before 2.3.20 uses predictable values, which allows remote attackers to bypass the CSRF protection mechanism.
+cvss_v2: 6.8
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-7809
+    - http://struts.apache.org/docs/s2-023.html
+    - http://blog.h3xstream.com/2014/12/predicting-struts-csrf-token-cve-2014.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.3.16.3"
+      fixedin:
+        - ">=2.3.20"


### PR DESCRIPTION
Note on libraries with no fix:
- Apache Axis does not have a release fix only a patch (https://issues.apache.org/jira/browse/AXIS-2905)
- ESAPI CVE-2013-5960 is a design problem that it is not currently fixed. (see Kevin Wall blog post)
