### PR TITLE
Additions to the validation script

### DIFF
--- a/database/java/2009/1190.yaml
+++ b/database/java/2009/1190.yaml
@@ -1,5 +1,5 @@
 cve: 2009-1190
-title: "Spring Framework: Remote classloader modification"
+title: "Spring Framework: Regular expression denial of service (ReDOS)"
 description: >
     Algorithmic complexity vulnerability in the java.util.regex.Pattern.compile method in Sun Java Development Kit (JDK) before 1.6, when used with spring.jar in SpringSource Spring Framework 1.1.0 through 2.5.6 and 3.0.0.M1 through 3.0.0.M2 and dm Server 1.0.0 through 1.0.2, allows remote attackers to cause a denial of service (CPU consumption) via serializable data with a long regex string containing multiple optional groups, a related issue to CVE-2004-2540.
 cvss_v2: 5.0

--- a/database/java/2009/1190.yaml
+++ b/database/java/2009/1190.yaml
@@ -1,0 +1,18 @@
+cve: 2009-1190
+title: "Spring Framework: Remote classloader modification"
+description: >
+    Algorithmic complexity vulnerability in the java.util.regex.Pattern.compile method in Sun Java Development Kit (JDK) before 1.6, when used with spring.jar in SpringSource Spring Framework 1.1.0 through 2.5.6 and 3.0.0.M1 through 3.0.0.M2 and dm Server 1.0.0 through 1.0.2, allows remote attackers to cause a denial of service (CPU consumption) via serializable data with a long regex string containing multiple optional groups, a related issue to CVE-2004-2540.
+cvss_v2: 5.0
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2009-1190
+    - http://support.springsource.com/security/cve-2009-1190
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-core"
+      version:
+        - "<=1.2.9,1"
+        - "<=2.5.6,2"
+        - "<=3.0.0.M2,3.0"
+      fixedin:
+        - ">=2.5.6.SEC01,2"
+        - ">=3.0.1.RELEASE,3.0"

--- a/database/java/2009/4269.yaml
+++ b/database/java/2009/4269.yaml
@@ -1,0 +1,18 @@
+---
+cve: 2009-4269
+title: "Apache Derby: Weak password hash generation"
+description: >
+    The password hash generation algorithm in the BUILTIN authentication functionality for Apache Derby before 10.6.1.0 performs a transformation that reduces the size of the set of inputs to SHA-1, which produces a small search space that makes it easier for local and possibly remote attackers to crack passwords by generating hash collisions, related to password substitution.
+cvss_v2: 2.1
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2009-4269
+    - http://marcellmajor.com/derbyhash.html
+    - https://issues.apache.org/jira/browse/DERBY-4483
+    - http://db.apache.org/derby/releases/release-10.6.1.0.html#Fix+for+Security+Bug+CVE-2009-4269
+affected:
+    - groupId: "org.apache.derby"
+      artifactId: "derby"
+      version:
+        - "<=10.5.3.0_1,10.5"
+      fixedin:
+        - ">=10.6.1.0"

--- a/database/java/2010/1622.yaml
+++ b/database/java/2010/1622.yaml
@@ -1,0 +1,17 @@
+cve: 2010-1622
+title: "Spring Framework: Remote classloader modification"
+description: >
+    SpringSource Spring Framework 2.5.x before 2.5.6.SEC02, 2.5.7 before 2.5.7.SR01, and 3.0.x before 3.0.3 allows remote attackers to execute arbitrary code via an HTTP request containing class.classLoader.URLs[0]=jar: followed by a URL of a crafted .jar file.
+cvss_v2: 5.1
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2010-1622
+    - http://support.springsource.com/security/cve-2010-1622
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-core"
+      version:
+        - "<=2.5.6.SEC01,2"
+        - "<=3.0.2.RELEASE,3.0"
+      fixedin:
+        - ">=2.5.6.SEC02,2"
+        - ">=3.0.3.RELEASE,3.0"

--- a/database/java/2010/1870.yaml
+++ b/database/java/2010/1870.yaml
@@ -2,7 +2,7 @@
 cve: 2010-1870
 title: "Apache Struts2: XWork ParameterInterceptors bypass allows remote command execution"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-005
+    - http://struts.apache.org/docs/s2-005.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2011/1772.yaml
+++ b/database/java/2011/1772.yaml
@@ -2,7 +2,7 @@
 cve: 2011-1772
 title: "Apache Struts2: Multiple XSS flaws in XWork"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-006
+    - http://struts.apache.org/docs/s2-006.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2011/2730.yaml
+++ b/database/java/2011/2730.yaml
@@ -1,0 +1,17 @@
+cve: 2011-2730
+title: "Spring Framework: EL expressions double evaluation"
+description: >
+    VMware SpringSource Spring Framework before 2.5.6.SEC03, 2.5.7.SR023, and 3.x before 3.0.6, when a container supports Expression Language (EL), evaluates EL expressions in tags twice, which allows remote attackers to obtain sensitive information via a (1) name attribute in a (a) spring:hasBindErrors tag; (2) path attribute in a (b) spring:bind or (c) spring:nestedpath tag; (3) arguments, (4) code, (5) text, (6) var, (7) scope, or (8) message attribute in a (d) spring:message or (e) spring:theme tag; or (9) var, (10) scope, or (11) value attribute in a (f) spring:transform tag, aka "Expression Language Injection."
+cvss_v2: 7.5
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-2730
+    - http://support.springsource.com/security/cve-2011-2730
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-core"
+      version:
+        - "<=2.5.6.SEC02,2"
+        - "<=3.0.5.RELEASE,3.0"
+      fixedin:
+        - ">=2.5.6.SEC03,2"
+        - ">=3.0.6.RELEASE,3.0"

--- a/database/java/2011/3923.yaml
+++ b/database/java/2011/3923.yaml
@@ -2,7 +2,7 @@
 cve: 2011-3923
 title: "Apache Struts2: Remote code execution via OGNL injention in HTTP parameter values"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-009
+    - http://struts.apache.org/docs/s2-009.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2011/4367.yaml
+++ b/database/java/2011/4367.yaml
@@ -1,0 +1,17 @@
+cve: 2011-4367
+title: "Apache MyFaces: Directory traversal"
+description: >
+    Multiple directory traversal vulnerabilities in MyFaces JavaServer Faces (JSF) in Apache MyFaces Core 2.0.x before 2.0.12 and 2.1.x before 2.1.6 allow remote attackers to read arbitrary files via a .. (dot dot) in the (1) ln parameter to faces/javax.faces.resource/web.xml or (2) the PATH_INFO to faces/javax.faces.resource/.
+cvss_v2: 5.0
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2011-4367
+    - http://mail-archives.apache.org/mod_mbox/myfaces-dev/201202.mbox/%3C4F33ED1F.4070007@apache.org%3E
+affected:
+    - groupId: "org.apache.myfaces.core"
+      artifactId: "myfaces-impl"
+      version:
+        - "<=2.0.11,2.0"
+        - "<=2.1.5,2.1"
+      fixedin:
+        - ">=2.0.12,2.0"
+        - ">=2.1.6,2.1"

--- a/database/java/2012/0838.yaml
+++ b/database/java/2012/0838.yaml
@@ -1,0 +1,14 @@
+---
+cve: 2012-0838
+title: "Apache Struts2: OGNL expression unexpected evaluation on conversion error"
+description: >
+    Apache Struts 2 before 2.2.3.1 evaluates a string as an OGNL expression during the handling of a conversion error, which allows remote attackers to modify run-time data values, and consequently execute arbitrary code, via invalid input to a field.
+references:
+    - http://struts.apache.org/docs/s2-007.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.2.3,2"
+      fixedin:
+        - ">=2.2.3.1,2"

--- a/database/java/2012/1007.yaml
+++ b/database/java/2012/1007.yaml
@@ -1,0 +1,13 @@
+cve: 2012-1007
+title: "Struts1: Multiple cross-site scripting (XSS) vulnerabilities in samples"
+description: >
+     Multiple cross-site scripting (XSS) vulnerabilities in Apache Struts 1.3.10 allow remote attackers to inject arbitrary web script or HTML via (1) the name parameter to struts-examples/upload/upload-submit.do, or the message parameter to (2) struts-cookbook/processSimple.do or (3) struts-cookbook/processDyna.do.
+     The vulnerability applies only if the application is based on the previous code samples.
+cvss_v2: 4.3
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-1007
+affected:
+    - groupId: "struts"
+      artifactId: "struts"
+      version:
+        - "<=1.3.10"

--- a/database/java/2012/4386.yaml
+++ b/database/java/2012/4386.yaml
@@ -2,7 +2,7 @@
 cve: 2012-4386
 title: "Apache Struts2: CSRF protection bypass"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-010
+    - http://struts.apache.org/docs/s2-010.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2012/4387.yaml
+++ b/database/java/2012/4387.yaml
@@ -2,7 +2,7 @@
 cve: 2012-4387
 title: "Apache Struts2: Long parameter name DoS"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-011
+    - http://struts.apache.org/docs/s2-011.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/1856.yaml
+++ b/database/java/2013/1856.yaml
@@ -1,0 +1,18 @@
+---
+cve: 2013-1856
+title: "JRuby: File access with XML External Entities"
+description: >
+    There is a vulnerability in the JDOM backend to ActiveSupport's XML parser.  This could allow an attacker to perform a denial of service attack or gain access to files stored on the application server.  This vulnerability has been assigned the CVE identifier CVE-2013-1856.
+cvss_v2: 5.8
+references:
+    - http://www.openwall.com/lists/oss-security/2013/03/18/4
+    - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-1856
+affected:
+    - groupId: "org.jruby"
+      artifactId: "jruby"
+      version:
+        - "<=3.1.11"
+        - "<=3.2.12,3.2"
+      fixedin:
+        - ">=3.1.12"
+        - "<=3.2.13,3.2"

--- a/database/java/2013/1965.yaml
+++ b/database/java/2013/1965.yaml
@@ -2,7 +2,7 @@
 cve: 2013-1965
 title: "Apache Struts 2 Showcase: remote command execution"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-012
+    - http://struts.apache.org/docs/s2-012.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-showcase"

--- a/database/java/2013/1966.yaml
+++ b/database/java/2013/1966.yaml
@@ -2,8 +2,8 @@
 cve: 2013-1966
 title: "Apache Struts 2 remote command execution due to flaw in the includeParams attribute of URL and Anchor tags"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-013
-    - http://struts.apache.org/release/2.3.x/docs/s2-014
+    - http://struts.apache.org/docs/s2-013.html
+    - http://struts.apache.org/docs/s2-014.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/2115.yaml
+++ b/database/java/2013/2115.yaml
@@ -2,7 +2,7 @@
 cve: 2013-2115
 title: "Apache Struts 2 remote command execution due to flaw in the includeParams attribute of URL and Anchor tags"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-014
+    - http://struts.apache.org/docs/s2-014.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/2134.yaml
+++ b/database/java/2013/2134.yaml
@@ -2,7 +2,7 @@
 cve: 2013-2134
 title: "Apache Struts 2 arbitrary OGNL code execution via unsanitized wildcard matching"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-015
+    - http://struts.apache.org/docs/s2-015.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/2135.yaml
+++ b/database/java/2013/2135.yaml
@@ -2,7 +2,7 @@
 cve: 2013-2135
 title: "Apache Struts 2 arbitrary OGNL code execution via double evaluation"
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-015
+    - http://struts.apache.org/docs/s2-015.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/2248.yaml
+++ b/database/java/2013/2248.yaml
@@ -7,7 +7,7 @@ description: >
     location.
 cvss_v2: 6.8
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-017
+    - http://struts.apache.org/docs/s2-017.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/2251.yaml
+++ b/database/java/2013/2251.yaml
@@ -8,7 +8,7 @@ description: >
     possibility to inject server side code.
 cvss_v2: 6.8
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-016
+    - http://struts.apache.org/docs/s2-016.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/4310.yaml
+++ b/database/java/2013/4310.yaml
@@ -7,7 +7,7 @@ description: >
     buttons within forms."
 cvss_v2: 5.8
 references:
-    - http://struts.apache.org/release/2.3.x/docs/s2-018
+    - http://struts.apache.org/docs/s2-018.html
 affected:
     - groupId: "org.apache.struts"
       artifactId: "struts2-core"

--- a/database/java/2013/4316.yaml
+++ b/database/java/2013/4316.yaml
@@ -1,0 +1,15 @@
+---
+cve: 2013-4316
+title: "Apache Struts2: Dynamic Method Invocation"
+description: >
+    Apache Struts 2.0.0 through 2.3.15.1 enables Dynamic Method Invocation by default, which has unknown impact and attack vectors.
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-4316
+    - http://struts.apache.org/docs/s2-019.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.3.15.1,2"
+      fixedin:
+        - ">=2.3.15.2,2"

--- a/database/java/2014/0053.yaml
+++ b/database/java/2014/0053.yaml
@@ -1,0 +1,23 @@
+cve: 2014-0053
+title: "Grails Resources plugin: Information disclosure"
+description: >
+    The Grails resources plug-in, a default dependency of Grails since 2.0.0, does not block access to resources located under /WEB-INF or /META-INF by default. This means that both configuration files and class files are publicly accessible when they should be private. Further, the filtering mechanism that applies any configured block does not normalize the requested URI before filtering allowing the block to be bypassed via directory traversal.
+cvss_v2: 5.0
+references:
+    - http://www.pivotal.io/security/cve-2014-0053
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0053
+    - https://grails.org/version/2.3.7%20Release%20Notes/9
+affected:
+    - groupId: "org.grails"
+      artifactId: "grails-resources"
+      version:
+        - "<=2.3.6,2"
+      fixedin:
+        - ">=2.3.7,2"
+
+    - groupId: "org.grails"
+      artifactId: "grails-core"
+      version:
+        - "<=2.3.6,2"
+      fixedin:
+        - ">=2.3.7,2"

--- a/database/java/2014/0054.yaml
+++ b/database/java/2014/0054.yaml
@@ -1,0 +1,21 @@
+cve: 2014-0054
+title: "Spring MVC: XML External Entities"
+description: >
+    Spring MVC's Jaxb2RootElementHttpMessageConverter also processed user provided XML and 
+    neither disabled XML external entities nor provided an option to disable them.
+    Jaxb2RootElementHttpMessageConverter has been modified to provide an option to control 
+    the processing of XML external entities and that processing is now disabled by default.
+cvss_v2: 6.8
+references:
+    - http://www.pivotal.io/security/cve-2014-0054
+    - https://jira.spring.io/browse/SPR-11376
+    - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0054
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-webmvc"
+      version:
+        - "<=3.2.7.RELEASE,3.2"
+        - "<=4.0.1.RELEASE,4.0"
+      fixedin:
+        - ">=3.2.8.RELEASE,3.2"
+        - ">=4.0.2.RELEASE,4.0"

--- a/database/java/2014/0094.yaml
+++ b/database/java/2014/0094.yaml
@@ -1,0 +1,18 @@
+---
+cve: 2014-0094
+title: "Apache Struts2: Incomplete fix for ClassLoader manipulation via ParametersInterceptor"
+description: >
+    The ParametersInterceptor in Apache Struts before 2.3.16.1 allows remote attackers to "manipulate" the ClassLoader via the class parameter, which is passed to the getClass method.
+    This CVE is kept for reference. The actual fix is attached to CVE-2014-0112/CVE-2014-0113.
+references:
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0094
+    - http://packetstormsecurity.com/files/127215/VMware-Security-Advisory-2014-0007.html
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0113
+    - http://struts.apache.org/docs/s2-021.html
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts2-core"
+      version:
+        - "<=2.3.16.1,2"
+      fixedin:
+        - ">=2.3.16.2,2"

--- a/database/java/2014/0114.yaml
+++ b/database/java/2014/0114.yaml
@@ -1,0 +1,18 @@
+cve: 2014-0114
+title: "Commons BeanUtils: Class Loader manipulation via request parameters"
+description: >
+     Apache Commons BeanUtils, as distributed in lib/commons-beanutils-1.8.0.jar in Apache Struts 1.x through 1.3.10 and in other products requiring commons-beanutils through 1.9.2, does not suppress the class property, which allows remote attackers to "manipulate" the ClassLoader and execute arbitrary code via the class parameter, as demonstrated by the passing of this parameter to the getClass method of the ActionForm object in Struts 1.
+cvss_v2: 7.5
+references:
+    - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0114
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1091938
+    - http://h30499.www3.hp.com/t5/HP-Security-Research-Blog/Protect-your-Struts1-applications/ba-p/6463188#.U2J7xeaSxro
+affected:
+    - groupId: "commons-beanutils"
+      artifactId: "commons-beanutils"
+      version:
+        - "<=1.9.2"
+    - groupId: "struts"
+      artifactId: "struts"
+      version:
+        - "<=1.3.10"

--- a/database/java/2014/3578.yaml
+++ b/database/java/2014/3578.yaml
@@ -1,0 +1,21 @@
+cve: 2014-3578
+title: "Spring MVC: Directory traversal flaw"
+description: >
+    Some URLs were not sanitized correctly before use allowing an attacker to
+    obtain any file on the file system that was also accessible to process in
+    which the Spring web application was running.
+cvss_v2: 5.0
+references:
+    - http://www.pivotal.io/security/cve-2014-3578
+    - https://jira.spring.io/browse/SPR-12354
+    - http://jvndb.jvn.jp/en/contents/2014/JVNDB-2014-000054.html
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1131882
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-webmvc"
+      version:
+        - "<=3.2.8.RELEASE,3.2"
+        - "<=4.0.4.RELEASE,4.0"
+      fixedin:
+        - ">=3.2.9.RELEASE,3.2"
+        - ">=4.0.5.RELEASE,4.0"

--- a/database/java/2014/3584.yaml
+++ b/database/java/2014/3584.yaml
@@ -7,7 +7,7 @@ references:
     - https://issues.apache.org/jira/browse/CXF-5390
 affected:
     - groupId: "org.apache.cxf"
-    artifactId: "cxf-rt-rs-security-xml"
+      artifactId: "cxf-rt-rs-security-xml"
       version:
         - "<=2.6.10,2.6"
         - "<=2.7.7,2.7"

--- a/validation/validate_yaml.py
+++ b/validation/validate_yaml.py
@@ -1,6 +1,7 @@
 #!/usr/env python
 
 from logging import basicConfig, getLogger, INFO
+import os
 from os.path import isfile
 from re import compile as regex_compile, search, IGNORECASE
 from sys import argv, exit
@@ -164,13 +165,18 @@ LANGUAGE_FIELDS = {
     }
 }
 
+#Use to extract the year and the id from the path (ie: '.../2015/1337.yaml')
+REGEX_FILENAME_PARTS = regex_compile('[/\\\\](\d+)[/\\\\](\d+).yaml')
 
 def is_valid_doc(doc, fields, parents=[]):
     valid = True
+
+    #Validate required fields
     for key in get_required(fields):
         if key not in doc.keys():
             log.error('Field "%s" is required but not provided.', key)
 
+    #Validating fields names and values
     for key in doc.keys():
         try:
             if key not in fields.keys():
@@ -184,6 +190,28 @@ def is_valid_doc(doc, fields, parents=[]):
 
     return valid
 
+
+def is_coherent_with_filename(doc, filename):
+    """
+    Validates that the CVE id is matching the filename.
+    """
+    if ('cve' in doc):
+        doc_year,doc_id = doc['cve'].split('-')
+
+        results = REGEX_FILENAME_PARTS.findall(filename)
+        if(len(results)==1):
+            file_year, file_id = results[0]
+            filename_cve = "-".join(results[0])
+            if(doc_year != file_year):
+                log.error('Document specified "%s" expected "%s" (filename). Invalid CVE year.', doc['cve'], filename_cve)
+                return False
+            if(doc_id != file_id):
+                log.error('Document specified "%s" expected "%s" (filename). Invalid CVE id.', doc['cve'], filename_cve)
+                return False
+        else:
+            log.error('Unexpected filename "%s"', filename)
+            return False
+    return True
 
 def is_affected(arg):
     if not is_list(arg):
@@ -215,7 +243,7 @@ def validate(filename):
     with open(filename, 'r') as f:
         log.info('Validating %s', filename)
         doc = load(f.read())
-        if not is_valid_doc(doc, COMMON_FIELDS):
+        if not is_valid_doc(doc, COMMON_FIELDS) or not is_coherent_with_filename(doc,filename):
             log.error('Document %s is invalid.', filename)
             return 1
 
@@ -241,7 +269,17 @@ if __name__ == '__main__':
         usage()
 
     invalid_count = 0
-    for arg in argv[2:]:
-        invalid_count += validate(arg)
+    if(len(argv)> 2):
+        #Validate a single file
+        for arg in argv[2:]:
+            invalid_count += validate(arg)
+    else:
+        #Validate all the files for the given language
+        target_dir = 'database/'+_LANGUAGE
+        for root, dirs, files in os.walk(target_dir):
+            for name in files:
+                if name.endswith('.yaml'):
+                    invalid_count += validate(os.path.join(root, name))
 
+    print('%s error%s found during validation.' % (invalid_count,"s" if invalid_count else ""))
     exit(invalid_count)


### PR DESCRIPTION
Added the ability to scan all the files of the given language (instead of just a single file)

    $ python validation/validate_yaml.py python
    $ python validation/validate_yaml.py java

Added validation of the CVE id matching the filename.

    $ python validation/validate_yaml.py java
    [INFO] Validating field title
    [INFO] Validating field references
    [INFO] Validating field cvss_v2
    [ERROR] Document specified "2014-3625" expected "2014-3578" (filename). Invalid CVE id.
    [ERROR] Document database/java/2014/3578.yaml is invalid.

Bonus : Fix malformed YAML file.