### PR TITLE
Apache JSTL and Spring SockJS CVEs

### DIFF
--- a/database/java/2015/0201.yaml
+++ b/database/java/2015/0201.yaml
@@ -1,0 +1,16 @@
+cve: 2015-0201
+title: "Insufficiently random session id in Java SockJS client"
+description: >
+    Session id generation in the Java SockJS client is not sufficiently secure and could allow a user to send messages to another user's session.
+cvss_v2: 5.0
+references:
+    - http://pivotal.io/security/cve-2015-0201
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0201
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-webmvc"
+      version:
+        - ">=4.1.0,4.1"
+        - "<=4.1.4,4.1"
+      fixedin:
+        - ">=4.1.5,4.1"

--- a/database/java/2015/0254.yaml
+++ b/database/java/2015/0254.yaml
@@ -1,0 +1,15 @@
+cve: 2015-0254
+title: "XXE in Apache Standard Taglibs"
+description: >
+    Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks via a crafted XSLT extension in a (1) <x:parse> or (2) <x:transform> JSTL XML tag.
+cvss_v2: 7.5
+references:
+    - http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E
+    - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254
+affected:
+    - groupId: "org.apache.taglibs"
+      artifactId: "taglibs-standard-spec"
+      version:
+        - "<=1.2.2"
+      fixedin:
+        - ">=1.2.3"


### PR DESCRIPTION
CVE-2015-0201 and CVE-2015-0254 added.

Refs:
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0201
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254