### PR TITLE
Affected versions for CVE-2012-5633

### DIFF
--- a/database/java/2012/5633.yaml
+++ b/database/java/2012/5633.yaml
@@ -19,6 +19,6 @@ affected:
     - groupId: "org.apache.cxf"
       artifactId: "cxf-rt-ws-security"
       version:
-        - "<=2.5.7"
-        - "<=2.6.4"
-        - "<=2.7.0"
+        - "<=2.5.7,2.5"
+        - "<=2.6.4,2.6"
+        - "<=2.7.0,2.7"


### PR DESCRIPTION
I am testing victims vs. dependency-checker and found some glitches in CVE descriptions.