### PR TITLE
Spring CVE update + Derby DB new vulnerability

### DIFF
--- a/database/java/2015/0201.yaml
+++ b/database/java/2015/0201.yaml
@@ -8,7 +8,7 @@ references:
     - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0201
 affected:
     - groupId: "org.springframework"
-      artifactId: "spring-webmvc"
+      artifactId: "spring-websocket"
       version:
         - ">=4.1.0,4.1"
         - "<=4.1.4,4.1"

--- a/database/java/2015/1832.yaml
+++ b/database/java/2015/1832.yaml
@@ -1,0 +1,14 @@
+cve: 2015-1832
+title: "XXE in Apache Derby Database"
+description: >
+    The Derby XML datatype and XmlVTI can be exploited, via XXE-based attacks, 
+    to expose sensitive information or launch denial-of-service assaults.
+cvss_v2: 5.0
+references:
+    - https://issues.apache.org/jira/browse/DERBY-6807
+    - http://mail-archives.apache.org/mod_mbox/db-derby-dev/201505.mbox/%3CJIRA.12827400.1430855874000.6985.1430856060110@Atlassian.JIRA%3E
+affected:
+    - groupId: "org.apache.derby"
+      artifactId: "derby"
+      version:
+        - "<=10.11.1.1"


### PR DESCRIPTION
- Spring CVE update: A mistake I introduce previously. wrong artifact-id
- Unfixed Derby DB but the vulnerability details have been made public by the developers. (Temporary CVSS score)

See commits for details