### PR TITLE
CVE-2015-5211, CVE-2015-5258.

### DIFF
--- a/database/java/2015/5211.yaml
+++ b/database/java/2015/5211.yaml
@@ -1,0 +1,42 @@
+cve: 2015-5211
+title: "Spring Framework: reflected file download vulnerability"
+description: >
+    Under some situations, the Spring Framework is vulnerable to a Reflected File Download (RFD) attack.
+    The attack involves a malicious user crafting a URL with a batch script extension that results in the
+    response being downloaded rather than rendered and also includes some input reflected in the response.
+cvss_v2: 4.0
+references:
+    - http://pivotal.io/security/cve-2015-5211
+    - https://access.redhat.com/security/cve/cve-2015-5211
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring-web"
+      version:
+        - "<=4.2.1.RELEASE,4.2"
+        - "<=4.1.7.RELEASE,4.1"
+        - "<=4.0.9.RELEASE,4.0"
+        - "<=3.2.14.RELEASE,3.2"
+      fixedin:
+        - ">=4.2.2.RELEASE,4.2"
+        - ">=4.1.8.RELEASE,4.1"
+        - ">=3.2.15.RELEASE,3.2"
+    - groupId: "org.springframework"
+      artifactId: "spring-webmvc"
+      version:
+        - "<=4.2.1.RELEASE,4.2"
+        - "<=4.1.7.RELEASE,4.1"
+        - "<=4.0.9.RELEASE,4.0"
+        - "<=3.2.14.RELEASE,3.2"
+      fixedin:
+        - ">=4.2.2.RELEASE,4.2"
+        - ">=4.1.8.RELEASE,4.1"
+        - ">=3.2.15.RELEASE,3.2"
+    - groupId: "org.springframework"
+      artifactId: "spring-websocket"
+      version:
+        - "<=4.2.1.RELEASE,4.2"
+        - "<=4.1.7.RELEASE,4.1"
+        - "<=4.0.9.RELEASE,4.0"
+      fixedin:
+        - ">=4.2.2.RELEASE,4.2"
+        - ">=4.1.8.RELEASE,4.1"

--- a/database/java/2015/5258.yaml
+++ b/database/java/2015/5258.yaml
@@ -1,0 +1,17 @@
+cve: 2015-5258
+title: "Spring Social Core: CSRF"
+description: >
+    When authorizing an application against an OAuth 2 API provider, Spring Social is vulnerable to a 
+    Cross-Site Request Forgery (CSRF) attack. No reference provided any CVSS score evaluation.
+cvss_v2: 4.0
+references:
+    - http://pivotal.io/security/cve-2015-5258
+    - https://blog.srcclr.com/spring-social-core-vulnerability-disclosure
+affected:
+    - groupId: "org.springframework.social"
+      artifactId: "spring-social-core"
+      version:
+        - "<=1.0.3.RELEASE,1.0"
+        - "<=1.1.2.RELEASE,1.1"
+      fixedin:
+        - ">=1.1.3.RELEASE"


### PR DESCRIPTION
This would close #36 and #37.

I have not run the validation, and I am not sure about using the "4.0" series for "4.1.6" fixes. It does also not cover "unsupported" (older) versions (but other yaml files did this not, too). There is no CVSS scores in the advisories of pivotal.