### PR TITLE
CVE-2016-3092: Apache Commons File Upload DoS

### DIFF
--- a/database/java/2016/3092.yaml
+++ b/database/java/2016/3092.yaml
@@ -1,0 +1,34 @@
+cve: 2016-3092
+title: "Apache Commons Fileupload: Denial of Service"
+description: >
+    A malicious client can send file upload requests that cause the HTTP server
+    using the Apache Commons Fileupload library to become unresponsive, preventing
+    the server from servicing other requests. A fork of this component
+    is also included in Apache Tomcat.
+cvss_v2: 4.3
+references:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1349475
+    - http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E
+    - http://tomcat.apache.org/security.html
+    - http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092
+affected:
+    - groupId: "commons-fileupload"
+      artifactId: "commons-fileupload"
+      version:
+        - "<=1.3.1,1.3"
+        - "<=1.2.2,1.2"
+      fixedin:
+        - ">=1.3.2,1.3"
+    - groupId: "org.apache.tomcat"
+      artifactId: "tomcat-catalina"
+      version:
+        - "<=9.0.0.M7,9"
+        - "<=8.5.2,8.5"
+        - "<=8.0.35,8.0"
+        - "<=7.0.69,7"
+      fixedin:
+        - ">=9.0.0.M8,9"
+        - ">=8.5.3,8.5"
+        - ">=8.0.36,8.0"
+        - ">=7.0.70,7"


### PR DESCRIPTION
The travis validate passes for this change. I am unsure about the CVSS score as there is not yet a public NVD entry.