### PR TITLE
Cve-2016-4970

### DIFF
--- a/database/java/2016/4970.yaml
+++ b/database/java/2016/4970.yaml
@@ -1,0 +1,18 @@
+cve: 2016-4970
+title: "Infinite Loop for SSL Handler"
+description: >
+    OpenSslEngine.wrap calls SSL_write which may return SSL_ERROR_WANT_READ, and if in this condition there is nothing to read from the BIO the OpenSslEngine and SslHandler will enter an infinite loop.
+references:
+    - http://netty.io/news/2016/06/07/4-1-1-Final.html
+    - http://netty.io/news/2016/06/07/4-0-37-Final.html
+affected:
+    - groupId: "io.netty"
+      artifactId: "netty-all"
+      version:
+        - "<=4.0.36.Final"
+        - "<=4.1.0.Final"
+      fixedin:
+        - ">=4.0.37.Final"
+        - ">=4.1.1.Final"
+      unaffected:
+        - "<=3.10.6.Final"


### PR DESCRIPTION
Netty CVE that is somehow fell off NVD and CVE's radar but is fixed 