### PR TITLE
Bulk CVE updates for 2016 2017

### DIFF
--- a/database/java/2016/4970.yaml
+++ b/database/java/2016/4970.yaml
@@ -15,7 +15,4 @@ affected:
         - ">=4.0.37.Final,4.0"
         - ">=4.1.1.Final,4.1"
       unaffected:
-          - groupId: "io.netty"
-            artifactId: "netty"
-            version:
-              - "<=3.10.6.Final,3"
+        - "<=3.10.6.Final,3"

--- a/database/java/2016/4970.yaml
+++ b/database/java/2016/4970.yaml
@@ -15,7 +15,7 @@ affected:
         - ">=4.0.37.Final,4.0"
         - ">=4.1.1.Final,4.1"
       unaffected:
-        - groupId: "io.netty"
-          arifactId: "netty"
-          version:
-            - "<=3.10.6.Final,3"
+          - groupId: "io.netty"
+            artifactId: "netty"
+            version:
+              - "<=3.10.6.Final,3"

--- a/database/java/2016/4970.yaml
+++ b/database/java/2016/4970.yaml
@@ -9,10 +9,13 @@ affected:
     - groupId: "io.netty"
       artifactId: "netty-all"
       version:
-        - "<=4.0.36.Final"
-        - "<=4.1.0.Final"
+        - "<=4.0.36.Final,4.0"
+        - "<=4.1.0.Final,4.1"
       fixedin:
-        - ">=4.0.37.Final"
-        - ">=4.1.1.Final"
+        - ">=4.0.37.Final,4.0"
+        - ">=4.1.1.Final,4.1"
       unaffected:
-        - "<=3.10.6.Final"
+        - groupId: "io.netty"
+          arifactId: "netty"
+          version:
+            - "<=3.10.6.Final,3"

--- a/database/java/2016/5007.yaml
+++ b/database/java/2016/5007.yaml
@@ -1,0 +1,19 @@
+cve: 2016-5007
+title: "Spring Security / MVC Path Matching Inconsistency"
+description: >
+    Both Spring Security and the Spring Framework rely on URL pattern mappings for authorization and for mapping requests to controllers respectively.
+references:
+    - https://pivotal.io/security/cve-2016-5007
+affected:
+    - groupId: "org.springframework.security"
+      artifactId: "spring-security-core"
+      version:
+        - "<=4.1.0.RELEASE"
+      fixedin:
+        - ">=4.1.1.RELEASE"
+    - groupId: "org.springframework"
+      artifactId: "spring-core"
+      version:
+        - "<=4.3.0.RELEASE"
+      fixedin:
+        - ">=4.3.1.RELEASE"

--- a/database/java/2016/9878.yaml
+++ b/database/java/2016/9878.yaml
@@ -10,9 +10,9 @@ affected:
       artifactId: "spring"
       version:
         - "<=3.2.17.RELEASE"
-        - "<=4.2.8.RELEASE"
-        - "<=4.3.4.RELEASE"
+        - "<=4.2.8.RELEASE,4.2"
+        - "<=4.3.4.RELEASE,4.3"
       fixedin:
-        - ">=3.2.18.RELEASE"
-        - ">=4.2.9.RELEASE"
-        - ">=4.3.5.RELEASE"
+        - ">=3.2.18.RELEASE,3.2"
+        - ">=4.2.9.RELEASE.4.2"
+        - ">=4.3.5.RELEASE,4.3"

--- a/database/java/2016/9879.yaml
+++ b/database/java/2016/9879.yaml
@@ -10,9 +10,9 @@ affected:
       artifactId: "spring-security-core"
       version:
         - "<=3.2.9.RELEASE"
-        - "<=4.1.3.RELEASE"
-        - "<=4.2.0.RELEASE"
+        - "<=4.1.3.RELEASE,4.1"
+        - "<=4.2.0.RELEASE,4.2"
       fixedin:
-        - ">=3.2.10.RELEASE"
-        - ">=4.1.4.RELEASE"
-        - ">=4.2.1.RELEASE"
+        - ">=3.2.10.RELEASE,3.2"
+        - ">=4.1.4.RELEASE,4.1"
+        - ">=4.2.1.RELEASE,4.2"

--- a/database/java/2017/5638.yaml
+++ b/database/java/2017/5638.yaml
@@ -1,0 +1,16 @@
+cve: 2017-5638
+title: "Possible Remote Code Execution when performing file upload based on Jakarta Multipart parser."
+description: >
+    The Jakarta Multipart parser in Apache Struts 2 2.3.x before 2.3.32 and 2.5.x before 2.5.10.1 mishandles file upload, which allows remote attackers to execute arbitrary commands via a #cmd= string in a crafted Content-Type HTTP header, as exploited in the wild in March 2017.
+references:
+    - https://cwiki.apache.org/confluence/display/WW/S2-045
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638
+affected:
+    - groupId: "org.apache.struts"
+      artifactId: "struts-core"
+      version:
+        - "<=2.3.31.RELEASE,2.3"
+        - "<=2.5.10.RELEASE,2.5"
+      fixedin:
+        - ">=2.3.32.RELEASE,2.3"
+        - ">=2.5.10.1.RELEASE"


### PR DESCRIPTION
Modified 2016-4970 - Unaffected version for netty uses different pom.
Modified 2016-9878, 2016-9879 - Per Jassiner, added series information
Added 2016-5007 - Spring Security + Framework for issue #49
Added 2017 folder under JAVA
Added 2017-5638 for Apache Stuts2 0-Day