### PR TITLE
Added CVE-2016-9571 for Apache Camel Jackson and Jacksonxml

### DIFF
--- a/database/java/2016/9571.yaml
+++ b/database/java/2016/9571.yaml
@@ -1,0 +1,29 @@
+cve: 2016-9571
+title: "Apache Camel's Jackson and JacksonXML unmarshalling operation are vulnerable to Remote Code Execution attacks"
+description: >
+    Apache Camel's camel-jackson and camel-jacksonxml components are vulnerable to Java object de-serialization vulnerability. Camel allows to specify such a type through the 'CamelJacksonUnmarshalType' property. De-serializing untrusted data can lead to security flaws as demonstrated in various similar reports about Java de-serialization issues.
+cvss_v2: 7.5
+references:
+    - http://camel.apache.org/security-advisories.data/CVE-2016-8749.txt.asc
+    - http://www.cvedetails.com/cve/CVE-2016-9571/
+affected:
+    - groupId: "org.apache.camel"
+      artifactId: "camel-jackson"
+      version:
+        - "<=2.16.4"
+        - "<=2.17.4,2.17"
+        - "<=2.18.1,2.18"
+      fixedin:
+        - "<=2.16.5,2.16"
+        - "<=2.17.5,2.17"
+        - "<=2.18.2,2.18"
+    - groupId: "org.apache.camel"
+      artifactId: "camel-jacksonxml"
+      version:
+        - "<=2.16.4,2.16"
+        - "<=2.17.4,2.17"
+        - "<=2.18.1,2.18"
+      fixedin:
+        - ">=2.16.5,2.16"
+        - ">=2.17.5,2.17"
+        - ">=2.18.2,2.18"

--- a/database/java/2017/5929.yaml
+++ b/database/java/2017/5929.yaml
@@ -1,0 +1,15 @@
+cve: 2017-5929
+title: "QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components."
+description: >
+    QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components.
+cvss_v2: 7.5
+references:
+    - https://logback.qos.ch/news.html
+    - http://www.cvedetails.com/cve/CVE-2017-5929/
+affected:
+    - groupId: "ch.qos.logback"
+      artifactId: "logback-core"
+      version:
+        - "<=1.2.0"
+      fixedin:
+        - ">=1.2.0"


### PR DESCRIPTION
Historical reference also points to CVE-2016-8749