### PR TITLE
CVE-2016-3720

### DIFF
--- a/database/java/2016/3720.yaml
+++ b/database/java/2016/3720.yaml
@@ -1,0 +1,16 @@
+cve: 2016-3720
+title: "jackson-dataformat-xml: XmlMapper is vulnerable to XXE attack"
+description: >
+    XML external entity (XXE) vulnerability in XmlMapper in the Data format extension for Jackson (aka jackson-dataformat-xml) allows attackers to have unspecified impact via unknown vectors.
+cvss_v2: 7.5
+references:
+    - https://github.com/FasterXML/jackson-dataformat-xml/issues/190
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1328427
+affected:
+    - groupId: "com.fasterxml.jackson.dataformat"
+      artifactId: "jackson-dataformat-xml"
+      version:
+        - "<=2.7.3"
+      fixedin:
+        - ">=2.7.4,2.7"
+        - ">=2.8.0"


### PR DESCRIPTION
Jackson-dataformat-xml - 
We didn't have it so I added it in specifically to jackson-dataformat-xml only so jackson-core isn't called out.

@jasinner 
@ashcrow 