### PR TITLE
fix CVE-2017-7669 to not match earlier versions and correct references

### DIFF
--- a/database/java/2017/7669.yaml
+++ b/database/java/2017/7669.yaml
@@ -4,16 +4,15 @@ description: >
     The LinuxContainerExecutor runs docker commands as root with insufficient input validation. When the docker feature is enabled, authenticated users can run commands as root
 cvss_v2: 6.0
 references:
-    - https://bugzilla.redhat.com/show_bug.cgi?id=1448373
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7669
     - http://seclists.org/oss-sec/2017/q2/394
-    - https://github.com/apache/hadoop/pull/126
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1448373
 affected:
     - groupId: "org.apache.hadoop"
-      artifactId: "hadoop-common"
+      artifactId: "hadoop-yarn-server-nodemanager"
       version:
-        - "<=2.8.0"
+        - "==2.8.0,2.8"
         - "<=3.0.0-alpha2,3.0"
       fixedin:
-        - ">=2.8.1"
+        - ">=2.8.1,2.8"
         - ">=3.0.0-alpha3,3.0"


### PR DESCRIPTION
The data for CVE-2017-7669 in the victims db is too aggressive and some details are incorrect:

The Java-part of the vulnerability is in hadoop-yarn-server-nodemanager and the feature itself was only introduced in 3.0.0-alpha1 and back-ported to 2.8.0.  The feature (and therefore the vulnerability) never appeared in earlier versions.

The pull request is completely unrelated.  Additionally, the RH bugzilla link is to a collection of CVEs and is probably the least relevant for those looking for more information.

As an aside: there should probably be some data verification for the CVEs listed in the DB.