### PR TITLE
Update schema with new fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The document requires all `required` fields in the [Common Content Schema](#comm
 |`cvss_v2`|`optional`|`float`|The CVSS v2 score for the flaw.|
 |`references`|`optional`|`list`:`url`|Reference url(s) for the flaw.|
 |`affected`|`required`|`list`:`language-module`|Affected language modules.|
+|`hash` | added later | `string` | Hash of the overall package.|
+| `file_hashes`| added later | `list`: `dict` of hash and name | Hashes for specific files in the package|
 
 #### `version-string`: `common`
 The version strings across all languages are expecte to match the regex:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ The document requires all `required` fields in the [Common Content Schema](#comm
 |`affected`|`required`|`list`:`language-module`|Affected language modules.|
 |`hash` | added later | `string` | Hash of the overall package.|
 | `file_hashes`| added later | `list`: `dict` of hash and name | Hashes for specific files in the package|
+| `package_url`| required | `string` | Template URL of where the artifacts may be found |
+
+#### package_url
+
+The package_url field currently supports a templated http string. There will be future supported added for
+real [package-urls](https://github.com/package-url/purl-spec). In the meantime the template string supports
+a few fields which are generated from the victims-cve-db entry itself:
+
+| Name    | Description                        |
+|---------|------------------------------------|
+| name    | The name of the artifact           |
+| version | The version number of the artifact |
+
+Example ``package_url`` templates include:
+
+```
+http://repo.maven.apache.org/maven2/HTTPClient/HTTPClient/{version}/HTTPClient-{version}.jar
+```
+
+```
+http://repo.spring.io/release/org/aspectj/{name}/{version}/{name}-{version}.jar  
+```
+
+This will be expanded when doing package hashing for each affected version in the victims-cve-db entry. As an example if
+``http://example.org/{name}-{version}.jar`` had a name of ``test`` a single affected of ``<=2.18.2,2.18`` the hashing
+would expand to pull down
+
+- http://example.org/test-2.18.2.jar
+- http://example.org/test-2.18.1.jar
+- http://example.org/test-2.18.0.jar
+
+**Note**: Java archives will have their ``name`` pulled from ``artifactId``.
 
 #### `version-string`: `common`
 The version strings across all languages are expecte to match the regex:

--- a/samples/java.yaml
+++ b/samples/java.yaml
@@ -18,3 +18,9 @@ affected:
         - "<=2.2.2.GA"
       fixedin:
         - ">=2.3.1"
+hash: 343e42ccbc5216a8a3de8967ec37fad0a3bd0d21f4a7322ca744836eaad1c0d3
+file_hashes:
+  - name: a/file/example
+    hash: 9e33c50ad962b381af4ed53c681d07c828f62afe3f2aac5a64c553528c55ecf9
+  - name: a/nother/file
+    hash: 90ce9edc82884247d8a42021cb63cb67a3f890c9591e28a35242bebd4a51731a

--- a/samples/python.yaml
+++ b/samples/python.yaml
@@ -18,3 +18,9 @@ affected:
         - "<=2.6.1,2.6"
       fixedin:
         - ">=2.6.2"
+hash: 343e42ccbc5216a8a3de8967ec37fad0a3bd0d21f4a7322ca744836eaad1c0d3
+file_hashes:
+  - name: a/file/example
+    hash: 9e33c50ad962b381af4ed53c681d07c828f62afe3f2aac5a64c553528c55ecf9
+  - name: a/nother/file
+    hash: 90ce9edc82884247d8a42021cb63cb67a3f890c9591e28a35242bebd4a51731a

--- a/validation/validate_yaml.py
+++ b/validation/validate_yaml.py
@@ -191,6 +191,7 @@ def is_valid_doc(doc, fields, parents=[]):
     for key in get_required(fields):
         if key not in doc.keys():
             log.error('Field "%s" is required but not provided.', key)
+            valid = False
 
     # Validating fields names and values
     for key in doc.keys():

--- a/validation/validate_yaml.py
+++ b/validation/validate_yaml.py
@@ -264,6 +264,7 @@ COMMON_FIELDS = {
     'affected': FieldValidator([is_affected]),
     'hash': FieldValidator([is_string], False),
     'file_hashes': FieldValidator([is_file_hashes], False),
+    'package_url': FieldValidator([is_url]),
 }
 
 

--- a/validation/validate_yaml.py
+++ b/validation/validate_yaml.py
@@ -51,6 +51,20 @@ def is_string(arg, allow_multiline=False):
     return True
 
 
+def is_file_hashes(arg, allow_multiline=False):
+    if not isinstance(arg, list):
+        log.error('List value expected, got %s', str(type(arg)))
+        return False
+
+    malformed = False
+    for item in arg:
+        if not item.get('name') or not item.get('hash'):
+            log.error('Expected a name and hash.')
+            malformed = True
+
+    return not malformed
+
+
 def is_text(arg):
     return is_string(arg, True)
 
@@ -246,7 +260,9 @@ COMMON_FIELDS = {
     'cvss_v2': FieldValidator([is_cvss], False),
     'cvss_v3': FieldValidator([is_cvss], False),
     'references': FieldValidator([is_references], False),
-    'affected': FieldValidator([is_affected])
+    'affected': FieldValidator([is_affected]),
+    'hash': FieldValidator([is_string], False),
+    'file_hashes': FieldValidator([is_file_hashes], False),
 }
 
 


### PR DESCRIPTION
Adding new fields for https://blog.victi.ms/2018/01/22/upcoming-changes/. 

This change should be backwards compatible with items which currently do not have ``file_hashes`` nor ``hash``.