### PR TITLE
Fix CVE-2015-0254

### DIFF
--- a/database/java/2015/0254.yaml
+++ b/database/java/2015/0254.yaml
@@ -7,9 +7,25 @@ references:
     - http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E
     - https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254
 affected:
-    - groupId: "org.apache.taglibs"
-      artifactId: "taglibs-standard-spec"
+    - groupId: org.apache.taglibs
+      artifactId: taglibs-standard-impl
       version:
-        - "<=1.2.2"
+        - "<=1.2.1"
       fixedin:
         - ">=1.2.3"
+    - groupId: taglibs
+      artifactId: standard
+      version:
+        - "<=1.1.2"
+package_urls:
+    - http://central.maven.org/maven2/org/apache/taglibs/taglibs-standard-impl/1.2.1/taglibs-standard-impl-1.2.1.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0/standard-1.0.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0.1/standard-1.0.1.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0.2/standard-1.0.2.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0.3/standard-1.0.3.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0.4/standard-1.0.4.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0.5/standard-1.0.5.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.0.6/standard-1.0.6.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.1.0/standard-1.1.0.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.1.1/standard-1.1.1.jar
+    - http://central.maven.org/maven2/taglibs/standard/1.1.2/standard-1.1.2.jar


### PR DESCRIPTION
`taglibs-standard-spec` artifact contains mostly interfaces, actual vulnerable implementation lives in `taglibs-standard-impl`.

1.1.x and 1.0.x versions have different Maven coordinates.