### PR TITLE
Adjust CVE-2017-7525 groupId

### DIFF
--- a/database/java/2017/7525.yaml
+++ b/database/java/2017/7525.yaml
@@ -7,7 +7,7 @@ references:
     - https://www.github.com/mbechler/marshalsec/blob/master/marshalsec.pdf?raw=true
     - https://github.com/FasterXML/jackson-databind/issues/1737
 affected:
-    - groupId: "org.fasterxml.jackson.core"
+    - groupId: "com.fasterxml.jackson.core"
       artifactId: "jackson-databind"
       version:
         - "<=2.8.9,2.8"


### PR DESCRIPTION
Group id is not according to POM.xml
See:
    https://github.com/FasterXML/jackson-
databind/blob/master/pom.xml#L11
```
        - groupId: "org.fasterxml.jackson.core"
          artifactId: "jackson-databind"
```
Signed-off-by: Liron Levin <liron@twistlock.com>