### PR TITLE
Fix CVE-2018-7489 version end

### DIFF
--- a/database/java/2018/7489.yaml
+++ b/database/java/2018/7489.yaml
@@ -19,8 +19,8 @@ affected:
     - groupId: "com.fasterxml.jackson.core"
       artifactId: "jackson-databind"
       version:
-        - "<=2.8.11.1,2.8"
+        - "<2.8.11.1,2.8"
         - "<=2.9.4,2.9"
       fixedin:
-        - ">=2.8.11.2,2.8"
+        - ">=2.8.11.1,2.8"
         - ">=2.9.5,2.9"


### PR DESCRIPTION
Fix affected versions end exluding:

https://nvd.nist.gov/vuln/detail/CVE-2018-7489
versionEndExcluding: 2.8.11.1